### PR TITLE
Various fixes and tweaks

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,5 +2,8 @@
   "extends": "airbnb-base",
   "env": {
     "node": true
+  },
+  "rules": {
+    "no-console": "off"
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,6 @@
 {
   "extends": "airbnb-base",
+  "env": {
+    "node": true
+  }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -2,8 +2,5 @@
   "extends": "airbnb-base",
   "env": {
     "node": true
-  },
-  "rules": {
-    "no-console": "off"
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,3 @@
 {
-  "extends": "airbnb-base",
-  "env": {
-    "node": true
-  }
+  "extends": "airbnb-base"
 }

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Windows devs will probably have things checked out as CRLF which makes eslint confused, so force LF line endnings at all times
+*.html  text eol=lf
+*.js    text eol=lf
+*.json  text eol=lf
+
+# Don't attempt merging on these files, as they are auto generated (Note this make git treat these as binary even though technically they are not)
+yarn.lock -diff
+package-lock.json -diff

--- a/.tools/mock-chat/index.js
+++ b/.tools/mock-chat/index.js
@@ -1,7 +1,7 @@
 const WebSocket = require('ws');
 
 function formatMessage(nick, message) {
-  return `MSG ${JSON.stringify({ nick, message })}`;
+  return `MSG ${JSON.stringify({ nick, data: message })}`;
 }
 
 function parseMessage(message) {

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,20 @@
+Copyright (c) 2018 Destiny.gg Chat Bot Authors
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ See below for local development of the bot.
 
 ```
 npm install
-npm run start
+npm start
 ```
 
 ## Contribution And Development

--- a/lib/chat-utils/parse-commands-from-chat.js
+++ b/lib/chat-utils/parse-commands-from-chat.js
@@ -29,7 +29,7 @@ function formatUnban(user) {
 
 function parseMessage(message) {
   const parsed = JSON.parse(message.replace('MSG ', ''));
-  return { user: parsed.nick, roles: parsed.features, message: parsed.message };
+  return { user: parsed.nick, roles: parsed.features, message: parsed.data };
 }
 
 function parseCommand(message) {

--- a/lib/chat-utils/parse-commands-from-chat.js
+++ b/lib/chat-utils/parse-commands-from-chat.js
@@ -29,7 +29,7 @@ function formatUnban(user) {
 
 function parseMessage(message) {
   const parsed = JSON.parse(message.replace('MSG ', ''));
-  return { user: parsed.nick, roles: parsed.features, message: parsed.data };
+  return { user: parsed.nick, roles: parsed.features, message: parsed.message };
 }
 
 function parseCommand(message) {

--- a/lib/message-routing/command-router.js
+++ b/lib/message-routing/command-router.js
@@ -1,4 +1,3 @@
-/* eslint-disable class-methods-use-this */
 const _ = require('lodash');
 const privledgedUserRoles = require('../chat-utils/privledged-user-list');
 
@@ -30,7 +29,7 @@ class CommandRouter {
     return Promise.resolve(false);
   }
 
-  checkPermission(privilegedCommand, roles) {
+  static checkPermission(privilegedCommand, roles) {
     if (privilegedCommand === true) {
       return !_.some(roles, role => privledgedUserRoles[role]);
     }

--- a/lib/services/punishment-read-write-stream.js
+++ b/lib/services/punishment-read-write-stream.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-underscore-dangle */
 const { Transform } = require('stream');
 
 class PunishmentReadWriteStream extends Transform {

--- a/lib/services/twitch-api.js
+++ b/lib/services/twitch-api.js
@@ -1,5 +1,3 @@
-
-/* eslint-disable */
 const TwitchClient = require('twitch').default;
 const axios = require('axios');
 
@@ -41,6 +39,7 @@ class TwitchApi {
     this.twitchClient.channels.getChannel('18074328').then((data) => {
       console.log(data.status);
     }).catch((err) => {
+      console.log(err);
     });
   }
 }

--- a/lib/services/twitch-api.js
+++ b/lib/services/twitch-api.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+
 const TwitchClient = require('twitch').default;
 const axios = require('axios');
 

--- a/lib/services/twitch-chat.js
+++ b/lib/services/twitch-chat.js
@@ -1,4 +1,4 @@
-const TwitchJs = require('twitch-js');
+const { client: TwitchJsClient } = require('twitch-js');
 const _ = require('lodash');
 const EventEmitter = require('events');
 const { parseCommand } = require('../chat-utils/parse-commands-from-chat');
@@ -29,8 +29,7 @@ class TwitchChatListener extends EventEmitter {
   }
 
   connect() {
-    // eslint-disable-next-line new-cap
-    this.client = new TwitchJs.client(this.options);
+    this.client = new TwitchJsClient(this.options);
     this.client.on('message', this.parseMessages.bind(this));
     this.client.on('connected', (e) => {
       this.emit('open', e);

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "Chat bot for destiny.gg chat",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha tests/**/*.test.js --exit --reporter spec",
-    "lint": "./node_modules/.bin/eslint index.js ./lib/**/*.js",
-    "start": "node index.js | ./node_modules/bunyan/bin/bunyan"
+    "test": "mocha tests/**/*.test.js --exit --reporter spec",
+    "lint": "eslint index.js ./lib/**/*.js",
+    "start": "node index.js | bunyan"
   },
   "author": "linusred",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "./node_modules/mocha/bin/mocha tests/**/*.test.js --exit --reporter spec",
-    "lint": "./node_modules/.bin/eslint index.js ./lib/**",
+    "lint": "./node_modules/.bin/eslint index.js ./lib/**/*.js",
     "start": "node index.js | ./node_modules/bunyan/bin/bunyan"
   },
   "author": "linusred",


### PR DESCRIPTION
- Adds license text, package.json specified MIT.
- Cleans up eslint stuff, so no eslint-disable are used anymore.
- Globally allow the use of console in eslint.
- Made it a bit more Windows dev friendly by enforcing LF line endnings in git, this avoids eslint complaining about them.
- I don't know why some lib devs insist on giving usage examples with hardcoded paths to executeables. Looking at you bunyan devs. Regardless it is fixed, so now these also work for Windows.
- Fixed a crash that always happened on second sent message