### PR TITLE
Regex banned phrases

### DIFF
--- a/lib/services/spam-detection.js
+++ b/lib/services/spam-detection.js
@@ -5,7 +5,7 @@ const similarity = require('../chat-utils/string-similarity');
 const matchStringOrRegex = (message, phrase) => {
   const cleanMessage = message.toLowerCase().trim();
   const cleanPhrase = phrase.trim();
-  if (/\/.*\//.test(cleanPhrase)) {
+  if (/^\/.*\/$/.test(cleanPhrase)) {
     const regexString = cleanPhrase.slice(1, cleanPhrase.length - 1);
     if (cleanPhrase.length <= 2) return false;
     const regex = new RegExp(regexString, 'i');

--- a/lib/services/spam-detection.js
+++ b/lib/services/spam-detection.js
@@ -4,14 +4,14 @@ const similarity = require('../chat-utils/string-similarity');
 // This is basically all punctuation that exists in ascii or otherwise.
 const matchStringOrRegex = (message, phrase) => {
   const cleanMessage = message.toLowerCase().trim();
-  const cleanPhrase = phrase.toLowerCase().trim();
-  if (cleanPhrase.startsWith('regex:')) {
-    const regexString = phrase.trim().slice(6);
-    if (regexString === '') return false;
+  const cleanPhrase = phrase.trim();
+  if (/\/.*\//.test(cleanPhrase)) {
+    const regexString = cleanPhrase.slice(1, cleanPhrase.length - 1);
+    if (cleanPhrase.length <= 2) return false;
     const regex = new RegExp(regexString, 'i');
     return regex.test(cleanMessage);
   }
-  return _.includes(cleanMessage, cleanPhrase);
+  return _.includes(cleanMessage, cleanPhrase.toLowerCase());
 };
 class SpamDetection {
   constructor(config) {

--- a/lib/services/spam-detection.js
+++ b/lib/services/spam-detection.js
@@ -2,7 +2,17 @@ const _ = require('lodash');
 const similarity = require('../chat-utils/string-similarity');
 
 // This is basically all punctuation that exists in ascii or otherwise.
-
+const matchStringOrRegex = (message, phrase) => {
+  const cleanMessage = message.toLowerCase().trim();
+  const cleanPhrase = phrase.toLowerCase().trim();
+  if (cleanPhrase.startsWith('regex:')) {
+    const regexString = phrase.trim().slice(6);
+    if (regexString === '') return false;
+    const regex = new RegExp(regexString, 'i');
+    return regex.test(cleanMessage);
+  }
+  return _.includes(cleanMessage, cleanPhrase);
+};
 class SpamDetection {
   constructor(config) {
     this.asciiArtThreshold = config.asciiArtThreshold || 20;
@@ -73,7 +83,7 @@ class SpamDetection {
   checkAgainstBannedPhrases(message) {
     let isBanned = false;
     this.bannedPhrases.forEach(phrase => {
-      if (_.includes(message.toLowerCase().trim(), phrase.text.toLowerCase().trim())) {
+      if (matchStringOrRegex(message, phrase.text)) {
         isBanned = phrase;
         return false;
       }

--- a/lib/services/spam-detection.js
+++ b/lib/services/spam-detection.js
@@ -85,9 +85,7 @@ class SpamDetection {
     this.bannedPhrases.forEach(phrase => {
       if (matchStringOrRegex(message, phrase.text)) {
         isBanned = phrase;
-        return false;
       }
-      return true;
     });
     return isBanned;
   }

--- a/tests/lib/services/spam-detection.test.js
+++ b/tests/lib/services/spam-detection.test.js
@@ -2,161 +2,240 @@ const assert = require('assert');
 const RollingChatCache = require('../../../lib/services/dgg-rolling-chat-cache');
 const SpamDetection = require('../../../lib/services/spam-detection');
 
-
 describe('Spam detection Tests', () => {
-  before(function () {
+  before(function() {
     this.spamDetection = new SpamDetection({});
   });
 
-  it('detects stupid non-ascii spam', function () {
-    const result = this.spamDetection.asciiSpamCheck('▒▒▓ ░▓█▀▄▒▓▒▒░░░▒▒░░▀▀▀▒▒▒▒░ ▓░ ░░░▓▓▓▓▒▒▒▒▒▒▒▒░░░▒▒▒▓▓░ ░░░░░▓▓▒░░▒▒▒▒▒▒▒▒▒▒▒▓▓░ ░░░░░░▓▒▒░░░░▒▒▒▒▒▒▒▓▓░░');
+  it('detects stupid non-ascii spam', function() {
+    const result = this.spamDetection.asciiSpamCheck(
+      '▒▒▓ ░▓█▀▄▒▓▒▒░░░▒▒░░▀▀▀▒▒▒▒░ ▓░ ░░░▓▓▓▓▒▒▒▒▒▒▒▒░░░▒▒▒▓▓░ ░░░░░▓▓▒░░▒▒▒▒▒▒▒▒▒▒▒▓▓░ ░░░░░░▓▒▒░░░░▒▒▒▒▒▒▒▓▓░░',
+    );
     assert.deepStrictEqual(result, true);
   });
 
-  it('detects stupid ascii art spam', function () {
-    const result = this.spamDetection.asciiSpamCheck(`@@@@@@@#!$!@4.124>!@4;.12>.;.;.12.3;..;.;.!@3>:@>:!@$:!@>$!:@$>!@$:!@$>:1515@@@@@#!$!@4.124>!@4;.12>.;.;.12.3;..;.;.!@3>:@>:!@$:!@>$!:`);
+  it('detects stupid ascii art spam', function() {
+    const result = this.spamDetection.asciiSpamCheck(
+      `@@@@@@@#!$!@4.124>!@4;.12>.;.;.12.3;..;.;.!@3>:@>:!@$:!@>$!:@$>!@$:!@$>:1515@@@@@#!$!@4.124>!@4;.12>.;.;.12.3;..;.;.!@3>:@>:!@$:!@>$!:`,
+    );
     assert.deepStrictEqual(result, true);
   });
 
-
-  it('Does not alert for normal sane messages', function () {
-    const result = this.spamDetection.asciiSpamCheck(`He'llo there sir!! I'm just typing some punctuated messages here. Shouldn't be too too many!!!! I am excited though!!!!!!! AHH!!!`);
+  it('Does not alert for normal sane messages', function() {
+    const result = this.spamDetection.asciiSpamCheck(
+      `He'llo there sir!! I'm just typing some punctuated messages here. Shouldn't be too too many!!!! I am excited though!!!!!!! AHH!!!`,
+    );
     assert.deepStrictEqual(result, false);
   });
 
-  it('does not checks lists for similar messages in the list if the string length is short.', function () {
+  it('does not checks lists for similar messages in the list if the string length is short.', function() {
     const chatCache = new RollingChatCache({});
     chatCache.addMessageToRunningList('linusred', 'hey nice meme man');
     chatCache.addMessageToRunningList('jimbo', 'hey');
 
-    const result = this.spamDetection.checkListOfMessagesForSpam('hey nice meme ma', chatCache.runningMessageList);
+    const result = this.spamDetection.checkListOfMessagesForSpam(
+      'hey nice meme ma',
+      chatCache.runningMessageList,
+    );
     assert.deepStrictEqual(result, false);
   });
 
-  it('does checks lists for similar messages in the list if the string length is long.', function () {
+  it('does checks lists for similar messages in the list if the string length is long.', function() {
     const chatCache = new RollingChatCache({});
-    chatCache.addMessageToRunningList('linusred', 'hey nice meme man hey nice meme man hey nice meme man hey nice meme man hey nice meme man hey nice meme man hey nice meme man hey nice meme man hey nice meme man hey nice meme man');
-    chatCache.addMessageToRunningList('jimbo', 'hey nice meme man hey nice meme man hey nice meme man hey nice meme man hey ni meme man hey nice meme man hey nice meme man hey nice meme man hey nice meme man hey ni meme man');
+    chatCache.addMessageToRunningList(
+      'linusred',
+      'hey nice meme man hey nice meme man hey nice meme man hey nice meme man hey nice meme man hey nice meme man hey nice meme man hey nice meme man hey nice meme man hey nice meme man',
+    );
+    chatCache.addMessageToRunningList(
+      'jimbo',
+      'hey nice meme man hey nice meme man hey nice meme man hey nice meme man hey ni meme man hey nice meme man hey nice meme man hey nice meme man hey nice meme man hey ni meme man',
+    );
 
-    const result = this.spamDetection.checkListOfMessagesForSpam('hey nice meme man hey nice meme man hey nice meme man hey nice meme man hey ni meme man hey nice meme man hey nice meme man hey nice meme man hey nice meme man hey ni meme man', chatCache.runningMessageList);
+    const result = this.spamDetection.checkListOfMessagesForSpam(
+      'hey nice meme man hey nice meme man hey nice meme man hey nice meme man hey ni meme man hey nice meme man hey nice meme man hey nice meme man hey nice meme man hey ni meme man',
+      chatCache.runningMessageList,
+    );
     assert.deepStrictEqual(result, true);
   });
 
-  it('should find a user with matched string messages and return them once', function () {
-    const chatCache = new RollingChatCache({messsagesToKeepPerUser: 10, maxMessagesInList: 2, timeToLive:0, tombStoneInterval: 0});
+  it('should find a user with matched string messages and return them once', function() {
+    const chatCache = new RollingChatCache({
+      messsagesToKeepPerUser: 10,
+      maxMessagesInList: 2,
+      timeToLive: 0,
+      tombStoneInterval: 0,
+    });
     const expected = ['linusred'];
     chatCache.addMessageToRunningList('linusred', 'hey nice meme man');
     chatCache.addMessageToRunningList('linusred', 'lol really nice meme man');
     chatCache.addMessageToRunningList('billy', 'stupid meme');
-    const result = this.spamDetection.getUsersWithMatchedMessage('nice meme', chatCache.runningMessageList);
+    const result = this.spamDetection.getUsersWithMatchedMessage(
+      'nice meme',
+      chatCache.runningMessageList,
+    );
     assert.deepStrictEqual(result, expected);
   });
 
-  it('should find users with matched string messages regardless of caps or trailing whitespace', function () {
-    const chatCache = new RollingChatCache({messsagesToKeepPerUser: 10, maxMessagesInList: 20, timeToLive:0, tombStoneInterval: 0});
+  it('should find users with matched string messages regardless of caps or trailing whitespace', function() {
+    const chatCache = new RollingChatCache({
+      messsagesToKeepPerUser: 10,
+      maxMessagesInList: 20,
+      timeToLive: 0,
+      tombStoneInterval: 0,
+    });
     const expected = ['coopy', 'linusred'];
     chatCache.addMessageToRunningList('linusred', 'hey nice meme man');
     chatCache.addMessageToRunningList('coopy', 'hey NiCe MeME    ');
     chatCache.addMessageToRunningList('billy', 'stupid meme');
-    const result = this.spamDetection.getUsersWithMatchedMessage('nice meme', chatCache.runningMessageList);
+    const result = this.spamDetection.getUsersWithMatchedMessage(
+      'nice meme',
+      chatCache.runningMessageList,
+    );
     assert.deepStrictEqual(result, expected);
   });
 
-  it('should find users with matched regex', function () {
-    const chatCache = new RollingChatCache({messsagesToKeepPerUser: 10, maxMessagesInList: 20, timeToLive:0, tombStoneInterval: 0});
+  it('should find users with matched regex', function() {
+    const chatCache = new RollingChatCache({
+      messsagesToKeepPerUser: 10,
+      maxMessagesInList: 20,
+      timeToLive: 0,
+      tombStoneInterval: 0,
+    });
     const expected = ['coopy', 'linusred'];
     chatCache.addMessageToRunningList('linusred', 'hey nice meme man');
     chatCache.addMessageToRunningList('coopy', 'hey NiCe MeME    ');
     chatCache.addMessageToRunningList('billy', 'stupid meme');
-    const result = this.spamDetection.getUsersWithMatchedMessage(/.*nice\s+meme.*/i, chatCache.runningMessageList);
+    const result = this.spamDetection.getUsersWithMatchedMessage(
+      /.*nice\s+meme.*/i,
+      chatCache.runningMessageList,
+    );
     assert.deepStrictEqual(result, expected);
   });
 
+  it('add phrases to the banned list and checks them', function() {
+    this.spamDetection.addBannedPhrase({ text: 'cool kid NO', duration: 600, type: 'mute' });
+    const isBanned = this.spamDetection.checkAgainstBannedPhrases(
+      'hello im such a cool kid NO lol',
+    );
 
-  it('add phrases to the banned list and checks them', function () {
-    this.spamDetection.addBannedPhrase({text:"cool kid NO", duration:600, type:'mute'});
-    const isBanned = this.spamDetection.checkAgainstBannedPhrases("hello im such a cool kid NO lol");
-
-    assert.deepStrictEqual(isBanned, {text:"cool kid NO", duration:600, type:'mute'});
+    assert.deepStrictEqual(isBanned, { text: 'cool kid NO', duration: 600, type: 'mute' });
   });
 
-  it('adds many phrases to the banned list and checks them', function () {
-    this.spamDetection.addBannedPhrase({text:"1", duration:600, type:'mute'});
-    this.spamDetection.addBannedPhrase({text:"2", duration:600, type:'mute'});
-    this.spamDetection.addBannedPhrase({text:"3", duration:600, type:'mute'});
+  it('adds many phrases to the banned list and checks them', function() {
+    this.spamDetection.addBannedPhrase({ text: '1', duration: 600, type: 'mute' });
+    this.spamDetection.addBannedPhrase({ text: '2', duration: 600, type: 'mute' });
+    this.spamDetection.addBannedPhrase({ text: '3', duration: 600, type: 'mute' });
     const isBanned = this.spamDetection.checkAgainstBannedPhrases('3');
 
-    assert.deepStrictEqual(isBanned, {text:"3", duration:600, type:'mute'});
+    assert.deepStrictEqual(isBanned, { text: '3', duration: 600, type: 'mute' });
   });
 
-  it('doesnt ban if phrase doesnt match', function () {
-    this.spamDetection.addBannedPhrase({text:"1", duration:600, type:'mute'});
-    this.spamDetection.addBannedPhrase({text:"2", duration:600, type:'mute'});
-    this.spamDetection.addBannedPhrase({text:"3", duration:600, type:'mute'});
-    const isBanned = this.spamDetection.checkAgainstBannedPhrases("5");
+  it('doesnt ban if phrase doesnt match', function() {
+    this.spamDetection.addBannedPhrase({ text: '1', duration: 600, type: 'mute' });
+    this.spamDetection.addBannedPhrase({ text: '2', duration: 600, type: 'mute' });
+    this.spamDetection.addBannedPhrase({ text: '3', duration: 600, type: 'mute' });
+    const isBanned = this.spamDetection.checkAgainstBannedPhrases('5');
 
     assert.deepStrictEqual(isBanned, false);
   });
 
-  it('bans unique word violations', function () {
-    const result = this.spamDetection.uniqueWordsCheck('KAPPA KAPPA KAPPA KAPPA KAPPA KAPPA KAPPA KAPPA KAPPA KAPPA KAPPA KAPPA KAPPA KAPPA KAPPA KAPPA KAPPA KAPPA KAPPA KAPPA');
+  it('bans unique word violations', function() {
+    const result = this.spamDetection.uniqueWordsCheck(
+      'KAPPA KAPPA KAPPA KAPPA KAPPA KAPPA KAPPA KAPPA KAPPA KAPPA KAPPA KAPPA KAPPA KAPPA KAPPA KAPPA KAPPA KAPPA KAPPA KAPPA',
+    );
     assert.deepStrictEqual(result, true);
   });
 
-  it('does not ban small unique word violations', function () {
+  it('does not ban small unique word violations', function() {
     const result = this.spamDetection.uniqueWordsCheck('KAPPA KAPPA KAPPA');
     assert.deepStrictEqual(result, false);
   });
 
-  it('bans unique word violations even if its tricky', function () {
-    const result = this.spamDetection.uniqueWordsCheck('KAPPA KAPPA KAPPA heh yeah right guys this will never work KAPPA KAPPA KAPPA yeah right guys KAPPA KAPPA KAPPA  KAPPA KAPPA KAPPA KAPPA KAPPA KAPPA');
+  it('bans unique word violations even if its tricky', function() {
+    const result = this.spamDetection.uniqueWordsCheck(
+      'KAPPA KAPPA KAPPA heh yeah right guys this will never work KAPPA KAPPA KAPPA yeah right guys KAPPA KAPPA KAPPA  KAPPA KAPPA KAPPA KAPPA KAPPA KAPPA',
+    );
     assert.deepStrictEqual(result, true);
   });
 
   it('matches nuked phrases with content and picks the highest one', function() {
-    const result = SpamDetection.isMessageNuked([{duration: 100, phrase:'abc'}, {duration: 500, phrase: '123'}], 'abc123');
-    assert.deepStrictEqual(result, { duration: 500, phrase: '123' })
+    const result = SpamDetection.isMessageNuked(
+      [
+        { duration: 100, phrase: 'abc' },
+        { duration: 500, phrase: '123' },
+      ],
+      'abc123',
+    );
+    assert.deepStrictEqual(result, { duration: 500, phrase: '123' });
   });
 
-
   it('matches case insensitive nuked phrases with content and picks the highest one', function() {
-    const result = SpamDetection.isMessageNuked([{duration: 100, phrase:'ABC'}, {duration: 500, phrase: '123'}], 'abc');
-    assert.deepStrictEqual(result, { duration: 100, phrase: 'ABC' })
+    const result = SpamDetection.isMessageNuked(
+      [
+        { duration: 100, phrase: 'ABC' },
+        { duration: 500, phrase: '123' },
+      ],
+      'abc',
+    );
+    assert.deepStrictEqual(result, { duration: 100, phrase: 'ABC' });
   });
 
   it('matches case insensitive nuked phrases with content', function() {
-    const result = SpamDetection.isMessageNuked([{duration: 100, phrase:'ABC'}, {duration: 500, phrase: 'AUT'}], 'AUT');
-    assert.deepStrictEqual(result, { duration: 500, phrase: 'AUT' })
+    const result = SpamDetection.isMessageNuked(
+      [
+        { duration: 100, phrase: 'ABC' },
+        { duration: 500, phrase: 'AUT' },
+      ],
+      'AUT',
+    );
+    assert.deepStrictEqual(result, { duration: 500, phrase: 'AUT' });
   });
 
   it('returns 0 on finding no matches', function() {
-    const result = SpamDetection.isMessageNuked([{duration: 100, phrase:'abc'}, {duration: 500, phrase: '123'}], 'eeeee');
-    assert.deepStrictEqual(result, { duration: 0, phrase: '' })
+    const result = SpamDetection.isMessageNuked(
+      [
+        { duration: 100, phrase: 'abc' },
+        { duration: 500, phrase: '123' },
+      ],
+      'eeeee',
+    );
+    assert.deepStrictEqual(result, { duration: 0, phrase: '' });
   });
 
   it('returns 0 on an empty nuke list', function() {
     const result = SpamDetection.isMessageNuked([], 'eeeee');
-    assert.deepStrictEqual(result, { duration: 0, phrase: '' })
+    assert.deepStrictEqual(result, { duration: 0, phrase: '' });
   });
 
   it('works with regex nuke phrases', function() {
-    const result = SpamDetection.isMessageNuked([{duration: 500,phrase: /abc/},{duration: 1000,phrase: '123'}], 'abc');
-    assert.deepStrictEqual(result, { duration: 500, phrase: '/abc/' })
+    const result = SpamDetection.isMessageNuked(
+      [
+        { duration: 500, phrase: /abc/ },
+        { duration: 1000, phrase: '123' },
+      ],
+      'abc',
+    );
+    assert.deepStrictEqual(result, { duration: 500, phrase: '/abc/' });
   });
 
-  it('mutes stupid repated things', function () {
-    const result = this.spamDetection.longRepeatedPhrase('Painstiny REE lol lol look at me AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHHHHHHHHHHHHHHHHHHHHHHHHH');
+  it('mutes stupid repated things', function() {
+    const result = this.spamDetection.longRepeatedPhrase(
+      'Painstiny REE lol lol look at me AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHHHHHHHHHHHHHHHHHHHHHHHHH',
+    );
     assert.deepStrictEqual(result, true);
   });
 
-  it('doesnt mute less stupid things', function () {
-    const result = this.spamDetection.longRepeatedPhrase('this is some phrase thats really long its nice that its really long lol this is awesome lol');
+  it('doesnt mute less stupid things', function() {
+    const result = this.spamDetection.longRepeatedPhrase(
+      'this is some phrase thats really long its nice that its really long lol this is awesome lol',
+    );
     assert.deepStrictEqual(result, false);
   });
 
-  it('doesnt mute even more less stupid things', function () {
-    const result = this.spamDetection.longRepeatedPhrase('www.reddit.com/awdawd look at my stupid look look at tihs lin khey kaw dkaw ai');
+  it('doesnt mute even more less stupid things', function() {
+    const result = this.spamDetection.longRepeatedPhrase(
+      'www.reddit.com/awdawd look at my stupid look look at tihs lin khey kaw dkaw ai',
+    );
     assert.deepStrictEqual(result, false);
   });
 });
-

--- a/tests/lib/services/spam-detection.test.js
+++ b/tests/lib/services/spam-detection.test.js
@@ -129,7 +129,21 @@ describe('Spam detection Tests', () => {
 
     assert.deepStrictEqual(isBanned, { text: '3', duration: 600, type: 'mute' });
   });
+  it('adds regex and properly matches', function() {
+    this.spamDetection.addBannedPhrase({ text: 'regex:h..lo', duration: 600, type: 'mute' });
 
+    const isBanned1 = this.spamDetection.checkAgainstBannedPhrases('match: h&&lo');
+    assert.deepStrictEqual(isBanned1, { text: 'regex:h..lo', duration: 600, type: 'mute' });
+
+    const isBanned2 = this.spamDetection.checkAgainstBannedPhrases('NOT match: h&&&lo');
+    assert.deepStrictEqual(isBanned2, false);
+  });
+  it("doesn't match empty regex", function() {
+    this.spamDetection.addBannedPhrase({ text: 'regex:', duration: 600, type: 'mute' });
+    const isBanned = this.spamDetection.checkAgainstBannedPhrases('Nothing should match regex:');
+
+    assert.deepStrictEqual(isBanned, false);
+  });
   it('doesnt ban if phrase doesnt match', function() {
     this.spamDetection.addBannedPhrase({ text: '1', duration: 600, type: 'mute' });
     this.spamDetection.addBannedPhrase({ text: '2', duration: 600, type: 'mute' });

--- a/tests/lib/services/spam-detection.test.js
+++ b/tests/lib/services/spam-detection.test.js
@@ -3,7 +3,7 @@ const RollingChatCache = require('../../../lib/services/dgg-rolling-chat-cache')
 const SpamDetection = require('../../../lib/services/spam-detection');
 
 describe('Spam detection Tests', () => {
-  before(function() {
+  beforeEach(function() {
     this.spamDetection = new SpamDetection({});
   });
 
@@ -140,9 +140,19 @@ describe('Spam detection Tests', () => {
   });
   it("doesn't match empty regex", function() {
     this.spamDetection.addBannedPhrase({ text: 'regex:', duration: 600, type: 'mute' });
-    const isBanned = this.spamDetection.checkAgainstBannedPhrases('Nothing should match regex:');
+    const isBanned = this.spamDetection.checkAgainstBannedPhrases(
+      'Nothing should match, even "regex:"',
+    );
 
     assert.deepStrictEqual(isBanned, false);
+  });
+  it('matches double-escaped regex characters as regex', function() {
+    this.spamDetection.addBannedPhrase({ text: 'regex:\\d\\d\\d', duration: 600, type: 'mute' });
+    const isBanned = this.spamDetection.checkAgainstBannedPhrases('Should match: 123');
+
+    assert.deepStrictEqual(isBanned, { text: 'regex:\\d\\d\\d', duration: 600, type: 'mute' });
+    const isBanned2 = this.spamDetection.checkAgainstBannedPhrases('Should NOT match: 12d');
+    assert.deepStrictEqual(isBanned2, false);
   });
   it('doesnt ban if phrase doesnt match', function() {
     this.spamDetection.addBannedPhrase({ text: '1', duration: 600, type: 'mute' });

--- a/tests/lib/services/spam-detection.test.js
+++ b/tests/lib/services/spam-detection.test.js
@@ -152,6 +152,15 @@ describe('Spam detection Tests', () => {
     const isBanned2 = this.spamDetection.checkAgainstBannedPhrases('Should NOT match: 12d');
     assert.deepStrictEqual(isBanned2, false);
   });
+  it('does not match regex within phrase', function() {
+    this.spamDetection.addBannedPhrase({ text: 'wow/bob/wow', duration: 600, type: 'mute' });
+
+    const isBanned = this.spamDetection.checkAgainstBannedPhrases('Should match: wow/bob/wow');
+    assert.deepStrictEqual(isBanned, { text: 'wow/bob/wow', duration: 600, type: 'mute' });
+
+    const isBanned2 = this.spamDetection.checkAgainstBannedPhrases('Should NOT match: bob');
+    assert.deepStrictEqual(isBanned2, false);
+  });
   it('doesnt ban if phrase doesnt match', function() {
     this.spamDetection.addBannedPhrase({ text: '1', duration: 600, type: 'mute' });
     this.spamDetection.addBannedPhrase({ text: '2', duration: 600, type: 'mute' });

--- a/tests/lib/services/spam-detection.test.js
+++ b/tests/lib/services/spam-detection.test.js
@@ -130,27 +130,25 @@ describe('Spam detection Tests', () => {
     assert.deepStrictEqual(isBanned, { text: '3', duration: 600, type: 'mute' });
   });
   it('adds regex and properly matches', function() {
-    this.spamDetection.addBannedPhrase({ text: 'regex:h..lo', duration: 600, type: 'mute' });
+    this.spamDetection.addBannedPhrase({ text: '/h..lo/', duration: 600, type: 'mute' });
 
     const isBanned1 = this.spamDetection.checkAgainstBannedPhrases('match: h&&lo');
-    assert.deepStrictEqual(isBanned1, { text: 'regex:h..lo', duration: 600, type: 'mute' });
+    assert.deepStrictEqual(isBanned1, { text: '/h..lo/', duration: 600, type: 'mute' });
 
     const isBanned2 = this.spamDetection.checkAgainstBannedPhrases('NOT match: h&&&lo');
     assert.deepStrictEqual(isBanned2, false);
   });
   it("doesn't match empty regex", function() {
-    this.spamDetection.addBannedPhrase({ text: 'regex:', duration: 600, type: 'mute' });
-    const isBanned = this.spamDetection.checkAgainstBannedPhrases(
-      'Nothing should match, even "regex:"',
-    );
+    this.spamDetection.addBannedPhrase({ text: '//', duration: 600, type: 'mute' });
+    const isBanned = this.spamDetection.checkAgainstBannedPhrases('Nothing should match, even //');
 
     assert.deepStrictEqual(isBanned, false);
   });
   it('matches double-escaped regex characters as regex', function() {
-    this.spamDetection.addBannedPhrase({ text: 'regex:\\d\\d\\d', duration: 600, type: 'mute' });
+    this.spamDetection.addBannedPhrase({ text: '/\\d\\d\\d/', duration: 600, type: 'mute' });
     const isBanned = this.spamDetection.checkAgainstBannedPhrases('Should match: 123');
 
-    assert.deepStrictEqual(isBanned, { text: 'regex:\\d\\d\\d', duration: 600, type: 'mute' });
+    assert.deepStrictEqual(isBanned, { text: '/\\d\\d\\d/', duration: 600, type: 'mute' });
     const isBanned2 = this.spamDetection.checkAgainstBannedPhrases('Should NOT match: 12d');
     assert.deepStrictEqual(isBanned2, false);
   });


### PR DESCRIPTION
Fixes #42 

- Works in !addmute and !addban, and anything that uses the `SpamDetection.checkAgainstBannedPhrases` function
- uses `/.../` syntax
    - Ex: `/h..lo/` matches `hello`, `h**lo`, `h&&lo`, but not
      `hel*o`
- escaped regex characters match literally
    - Ex: `/\.\./` matches only `..`, not 2 of any character
- escaped regex escape characters ("double" escaped) match as regex escape characters. Ex:
    - `/\\d\\d\\d/` matches 3 digits, reduces to `/\d\d\d/`

Regex string rules follow javascript's `new RegExp("<string here>", "i")` rules.