### PR TITLE
!mutelinks regex hotfix 2

### DIFF
--- a/lib/services/message-matching.js
+++ b/lib/services/message-matching.js
@@ -6,7 +6,10 @@ module.exports = {
   },
   mentionsUser(message, user) {
     if (!user) return false;
-    const regex = new RegExp(`(?<!\\S)(${user.toLowerCase()})(?!\\S)`, 'i');
+    const regex = new RegExp(
+      `((?:^|\\s)@?)(${user.toLowerCase()})(?=$|\\s|(?:\\?|\\!|\\,|\\.(?!\\S)))`,
+      'i',
+    );
     return regex.test(message);
   },
 };

--- a/lib/services/message-matching.js
+++ b/lib/services/message-matching.js
@@ -6,10 +6,7 @@ module.exports = {
   },
   mentionsUser(message, user) {
     if (!user) return false;
-    const regex = new RegExp(
-      `((?:^|\\s)@?)(${user.toLowerCase()})(?=$|\\s|(?:\\?|\\!|\\,|\\.(?!\\S)))`,
-      'i',
-    );
+    const regex = new RegExp(`((?:^|\\s)@?)(${user.toLowerCase()})(?=$|\\s|[?!,]|\\.(?!\\S))`, 'i');
     return regex.test(message);
   },
 };

--- a/tests/lib/commands/implementations/mutelinks.test.js
+++ b/tests/lib/commands/implementations/mutelinks.test.js
@@ -97,6 +97,14 @@ describe('Mutelinks Test', () => {
       message: 'wow i love this site destiny.gg',
       user: 'test6',
     });
+    messageRelay.relayMessageToListeners({
+      message: 'wow i love this site meme.com destiny.gg',
+      user: 'test7',
+    });
+    messageRelay.relayMessageToListeners({
+      message: 'wow i love this site meme.com destiny!',
+      user: 'test8',
+    });
 
     const output2 = mutelinks.work('off', this.mockServices);
     assert.deepStrictEqual(output2, new CommandOutput(null, 'Link muting turned off'));
@@ -106,7 +114,7 @@ describe('Mutelinks Test', () => {
       user: 'test7',
     });
 
-    assert.deepStrictEqual(punishmentStream.write.callCount, 2);
+    assert.deepStrictEqual(punishmentStream.write.callCount, 3);
     assert.deepStrictEqual(
       punishmentStream.write.getCall(0).args[0],
       makeMute('test4', 1200, 'test4 muted for 20m for posting a link while link muting is on.'),
@@ -114,6 +122,10 @@ describe('Mutelinks Test', () => {
     assert.deepStrictEqual(
       punishmentStream.write.getCall(1).args[0],
       makeMute('test5', 1200, 'test5 muted for 20m for posting a link while link muting is on.'),
+    );
+    assert.deepStrictEqual(
+      punishmentStream.write.getCall(2).args[0],
+      makeMute('test8', 1200, 'test8 muted for 20m for posting a link while link muting is on.'),
     );
   });
   it('message formats correctly and alerts of duplicate commands', function() {

--- a/tests/lib/services/message-matching.test.js
+++ b/tests/lib/services/message-matching.test.js
@@ -45,13 +45,16 @@ describe('Message matching tests ', () => {
     it('matches #2', () => assert.deepStrictEqual(mentionsUser('DesTiny hi', 'desTiny'), true));
     it('matches #3', () =>
       assert.deepStrictEqual(mentionsUser('destiny hi destiny destiny', 'DESTINY'), true));
+    it('matches #4', () => assert.deepStrictEqual(mentionsUser('destiny. hi', 'DESTINY'), true));
     it('matches #5', () => assert.deepStrictEqual(mentionsUser('destiny, yo gg', 'destiny'), true));
     it('matches #6', () => assert.deepStrictEqual(mentionsUser('destiny?', 'destiny'), true));
     it('matches #7', () => assert.deepStrictEqual(mentionsUser('destiny!', 'destiny'), true));
-    it('matches #8', () =>
+    it('not match #1', () =>
       assert.deepStrictEqual(mentionsUser('https://destiny!', 'destiny'), false));
-    it('matches #9', () => assert.deepStrictEqual(mentionsUser('destiny.gg', 'destiny'), false));
-    it('matches #10', () => assert.deepStrictEqual(mentionsUser('yodestiny.gg', 'destiny'), false));
-    it('matches #11', () => assert.deepStrictEqual(mentionsUser('yodestiny', 'destiny'), false));
+    it('not match #2', () => assert.deepStrictEqual(mentionsUser('destiny.gg', 'destiny'), false));
+    it('not match #3', () =>
+      assert.deepStrictEqual(mentionsUser('yodestiny.gg', 'destiny'), false));
+    it('not match #4', () => assert.deepStrictEqual(mentionsUser('yodestiny', 'destiny'), false));
+    it('not match #5', () => assert.deepStrictEqual(mentionsUser('destinyt', 'DESTINY'), false));
   });
 });

--- a/tests/lib/services/message-matching.test.js
+++ b/tests/lib/services/message-matching.test.js
@@ -45,6 +45,13 @@ describe('Message matching tests ', () => {
     it('matches #2', () => assert.deepStrictEqual(mentionsUser('DesTiny hi', 'desTiny'), true));
     it('matches #3', () =>
       assert.deepStrictEqual(mentionsUser('destiny hi destiny destiny', 'DESTINY'), true));
-    it('matches #3', () => assert.deepStrictEqual(mentionsUser('destiny.gg', 'destiny'), false));
+    it('matches #5', () => assert.deepStrictEqual(mentionsUser('destiny, yo gg', 'destiny'), true));
+    it('matches #6', () => assert.deepStrictEqual(mentionsUser('destiny?', 'destiny'), true));
+    it('matches #7', () => assert.deepStrictEqual(mentionsUser('destiny!', 'destiny'), true));
+    it('matches #8', () =>
+      assert.deepStrictEqual(mentionsUser('https://destiny!', 'destiny'), false));
+    it('matches #9', () => assert.deepStrictEqual(mentionsUser('destiny.gg', 'destiny'), false));
+    it('matches #10', () => assert.deepStrictEqual(mentionsUser('yodestiny.gg', 'destiny'), false));
+    it('matches #11', () => assert.deepStrictEqual(mentionsUser('yodestiny', 'destiny'), false));
   });
 });


### PR DESCRIPTION
Now uses the same mention regex as chat-gui does to highlight messages, with the exception that `mentionedusername.` (username followed by a period) will only count as a mention if it *isn't* immediately followed by a non-whitespace character. For example, mentioning destiny,

- `destiny` -> counts as a mention
- `destiny.` -> counts as a mention
- `destiny. hi` -> counts as a mention
- `destiny.gg` -> **does not** count as a mention
- `destiny. gg` -> counts as a mention

The implication of this is that urls won't also count as mentions, specifically to deal with the common case of someone typing `destiny.gg` and getting muted even while not trying to mention destiny.