### PR TITLE
Fix error not being logged to stdout

### DIFF
--- a/lib/message-routing/chat-service-router.js
+++ b/lib/message-routing/chat-service-router.js
@@ -55,7 +55,7 @@ class ChatServiceRouter {
             return;
           }
 
-          if (outputObject.err && outputObject.isWhisper === false) {
+          if (outputObject.err && !outputObject.isWhisper) {
             this.logger.error(
               'Purposeful error thrown by command',
               commandObject,


### PR DESCRIPTION
due to `isWhisper` being undefined on CommandOutput. I kept the behaviour, but why aren't we logging errors for whispers?