### PR TITLE
Added youtube-chat

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 const { argv } = require('yargs');
 
 const DestinyChat = require('./lib/services/destinychat');
+const YoutubeChat = require('./lib/services/youtube-chat');
 const TwitchChat = require('./lib/services/twitch-chat');
 const CommandRouter = require('./lib/message-routing/command-router');
 const Services = require('./lib/services/service-index');
@@ -52,8 +53,12 @@ services
       bot = new TwitchChat(config.twitch, services);
     } else if (chatToConnectTo === 'dgg') {
       bot = new DestinyChat(config.dggChat, services);
+    } else if (chatToConnectTo === 'youtube') {
+      bot = new YoutubeChat(config.youtubeChat, services);
     } else {
-      logger.error('Config property: "chatToConnectTo" not set to one of "dgg" or "twitch"');
+      logger.error(
+        'Config property: "chatToConnectTo" not set to one of "dgg", "twitch" or "youtube"',
+      );
       process.exit(1);
     }
     // Schedule some complex stuff

--- a/lib/services/youtube-chat.js
+++ b/lib/services/youtube-chat.js
@@ -1,0 +1,176 @@
+const _ = require('lodash');
+const EventEmitter = require('events');
+const { parseCommand } = require('../chat-utils/parse-commands-from-chat');
+
+// TODO: Remove debugs
+// TODO: Solution for channelId
+// TODO: Solution for unbans
+class YoutubeChatListener extends EventEmitter {
+  /**
+   * @param {import("../services/service-index")} services
+   */
+  constructor(config, services) {
+    super();
+    this.youtube = services.youtube;
+    this.logger = services.logger;
+
+    // TODO: Make configurable
+    this.livePollDelay = 1000;
+
+    this.isOnline = false;
+    this.liveChatId = null;
+    this.pageToken = '';
+  }
+
+  setOffline() {
+    this.isOnline = false;
+    this.liveChatId = null;
+    this.pageToken = null;
+  }
+
+  async connect() {
+    if (!this.isOnline || !this.liveChatId) {
+      this.logger.debug('Checking youtube live status');
+      const { isLive, liveChatId } = await this.youtube.getChannelStatus();
+      if (!isLive || !liveChatId) {
+        this.setOffline();
+        setTimeout(this.connect, this.livePollDelay);
+        return;
+      }
+      this.emit('open', true);
+      this.isOnline = true;
+      this.liveChatId = liveChatId || null;
+    }
+
+    try {
+      this.logger.debug('Fetching live youtube messages');
+      const messagesResponse = await this.youtube.getYoutubeApi().liveChatMessages.list({
+        liveChatId: this.liveChatId,
+        part: 'id,snippet,authorDetails',
+        ...(this.pageToken && { pageToken: this.pageToken }),
+      });
+      this.logger.debug(`Iterating over ${messagesResponse.data.items.length} messages`);
+      messagesResponse.data.items.forEach(this.parseMessages.bind(this));
+      this.pageToken = messagesResponse.pageToken;
+      // Only present if the stream is already offline
+      if (messagesResponse.data.offlineAt) {
+        this.setOffline();
+        setTimeout(this.connect, this.livePollDelay);
+        return;
+      }
+      this.logger.debug(
+        `Set to fetch next batch in ${messagesResponse.data.pollingIntervalMillis} milliseconds`,
+      );
+      setTimeout(this.connect, messagesResponse.data.pollingIntervalMillis);
+    } catch (err) {
+      this.logger.error('Problem getting batch of youtube live mesages:', err);
+      // Retry?
+      setTimeout(this.connect, this.livePollDelay);
+    }
+  }
+
+  sendMessage(message) {
+    this.youtube
+      .getYoutubeApi()
+      .liveChatMessages.insert({
+        part: ['snippet'],
+        snippet: {
+          liveChatId: this.liveChatId,
+          type: 'textMessageEvent',
+          textMessageDetails: {
+            messageText: message,
+          },
+        },
+      })
+      .catch((err) => {
+        this.logger.error('Error in youtube sendMessage:', err);
+      });
+  }
+
+  // eslint-disable-next-line no-unused-vars, class-methods-use-this
+  sendWhisper(user, message) {}
+
+  sendMute(punished) {
+    this.youtube
+      .getYoutubeApi()
+      .liveChatBans.insert({
+        part: ['snippet'],
+        resource: {
+          snippet: {
+            liveChatId: this.liveChatId,
+            type: 'temporary',
+            banDurationSeconds: Math.ceil(punished.duration),
+            bannedUserDetails: {
+              channelId: punished.user,
+            },
+          },
+        },
+      })
+      .then(this.sendMessage(punished.reason))
+      .catch((err) => this.logger.error('Error while muting on youtube:', err));
+  }
+
+  sendBan(punished) {
+    this.youtube
+      .getYoutubeApi()
+      .liveChatBans.insert({
+        part: ['snippet'],
+        resource: {
+          snippet: {
+            liveChatId: this.liveChatId,
+            type: punished.isPermanent ? 'permanent' : 'temporary',
+            ...(!punished.isPermanent && { banDurationSeconds: Math.ceil(punished.duration) }),
+            bannedUserDetails: {
+              channelId: punished.user,
+            },
+          },
+        },
+      })
+      .then(this.sendMessage(punished.reason))
+      .catch((err) => this.logger.error('Error while banning on youtube:', err));
+  }
+
+  // eslint-disable-next-line no-unused-vars, class-methods-use-this
+  sendUnban(punished) {
+    // No unbans! :hypers:
+    // Unbans require storing the ban id, should we do it?
+  }
+
+  // eslint-disable-next-line no-unused-vars, class-methods-use-this
+  sendUnmute(punished) {
+    // No Unmutes! :hypers:
+    // Unmutes require storing the ban id, should we do it?
+  }
+
+  /**
+   * @param {import("googleapis").youtube_v3.Schema$LiveChatMessage} message
+   */
+  parseMessages(message) {
+    const { authorDetails, snippet } = message;
+    if (snippet.type === 'textMessageEvent') {
+      const parsedMessage = {
+        user: authorDetails.channelId,
+        roles: [
+          authorDetails.isChatOwner && 'admin',
+          authorDetails.isChatModerator && 'moderator',
+          authorDetails.isChatSponsor && 'sponsor',
+          authorDetails.isVerified && 'verified',
+        ].filter((role) => !!role),
+        message: snippet.displayMessage,
+      };
+
+      if (_.startsWith(snippet.displayMessage, '!')) {
+        this.emit('command', {
+          parsedMessage,
+          isWhisper: false,
+          parsedCommand: parseCommand(snippet.displayMessage),
+        });
+      }
+      this.emit('message');
+    }
+
+    return this.logger;
+  }
+}
+
+module.exports = YoutubeChatListener;

--- a/lib/services/youtube.js
+++ b/lib/services/youtube.js
@@ -5,7 +5,8 @@ const moment = require('moment');
 class YouTube {
   constructor(configuration) {
     this.configuration = configuration;
-    this.scopes = ['https://www.googleapis.com/auth/youtube.readonly'];
+    // Not readyonly anymore to support inserting chat messages in youtube-chat
+    this.scopes = ['https://www.googleapis.com/auth/youtube'];
     this.youtube = google.youtube({
       version: 'v3',
       auth: this.configuration.YOUTUBE_API_KEY,
@@ -38,12 +39,7 @@ class YouTube {
         }),
       )
       .then((response) => _.find(response.data.items, ['kind', 'youtube#searchResult']))
-      .then((searchResult) => {
-        if (searchResult && searchResult.id && searchResult.id.videoId) {
-          return searchResult.id.videoId;
-        }
-        return null;
-      });
+      .then((searchResult) => _.get(searchResult, 'id.videoId', null));
   }
 
   getChannelStatus() {
@@ -63,6 +59,7 @@ class YouTube {
         ) {
           return {
             isLive: true,
+            liveChatId: searchResult.liveStreamingDetails.activeLiveChatId,
             viewers: searchResult.liveStreamingDetails.concurrentViewers,
             started: moment(
               searchResult.liveStreamingDetails.actualStartTime,
@@ -96,6 +93,10 @@ class YouTube {
         part: 'id',
       })
       .then((response) => _.find(response.data.items, ['kind', 'youtube#channel']).id);
+  }
+
+  getYoutubeApi() {
+    return this.youtube;
   }
 }
 


### PR DESCRIPTION
Adds chad service for the youtube live chat, still a few things to be considered:

**Should usernames be considered channelIds?**

On youtube, "display names" are not unique, rather the `channelId` of a channel (user) is unique. As such, doing any actions on display names doesn't work with the api. The solution would be to resolve channel ids from the display names, however because display names can be duplicated, there is no guarantee we resolve to the correct channel.

Additionally, display names on youtube can have spaces (and it's very common, if not the majority of users) which make it completely incompatible with our current system.

It seems to me that the only real path is using the `channelId`s as usernames, if we want to keep the general bot api the same, but this reduces the usability of the bot considerably.

**Storing unban/mute ids?**

In the youtube api, to ban a user you provide a `channelId` of that user. However, to *unban* a user, you have to use the `banId` returned from a succesful ban call. As far as I can tell, there's no way to list bans or otherwise resolve banIds from channelIds or usernames. Right now I"ve just got unbans just not doing anything.

The solution here would be to store `channelId:banId`s in sqlite or something, which doesn't seem ideal but maybe the only way to do it.

**Scope of commands that should apply to youtube?**

Given the first point, assuming we don't resolve it in a nice way, should moderation commands be disabled for youtube? Obviously not ideal, but idk if they serve much value without clean username resolution.