### PR TITLE
Redirect non-permanent twitch bans to mutes instead

### DIFF
--- a/lib/configuration/configure-commands.js
+++ b/lib/configuration/configure-commands.js
@@ -101,10 +101,6 @@ function registerCommandsFromFiles(commandRegistry, chatConnectedTo, config) {
     ]);
     commandRegistry.registerCommand('!gulag', gulag);
   }
-  if (chatConnectedTo === 'twitch') {
-    // All Twitch bans are by definition permanent, so alias addban to addmute
-    commandRegistry.registerCommand('!addban', addmute);
-  }
 }
 
 async function setupCommandsAndCachesFromDb(

--- a/lib/services/twitch-chat.js
+++ b/lib/services/twitch-chat.js
@@ -73,6 +73,10 @@ class TwitchChatListener extends EventEmitter {
   }
 
   sendBan(punished) {
+    if (!punished.isPermanent) {
+      this.sendMute(punished);
+      return;
+    }
     this.client
       .ban(this.channel, punished.user, punished.reason)
       .then(() => {


### PR DESCRIPTION
Reverts #88, which aliased !addban -> !addmute when issued on twitch.

This PR addresses the further conversation in #87, by now redirecting bans that are non-permanent in twitch to mutes.

This will now affect all 'ban' commands consistently, and allow for uniform command behavior between dgg and twitch
regardless of which chat the command was issued in.