### PR TITLE
Use etag to cache youtube responses

### DIFF
--- a/lib/services/youtube.js
+++ b/lib/services/youtube.js
@@ -77,7 +77,7 @@ class YouTube {
           searchResult.liveStreamingDetails &&
           searchResult.liveStreamingDetails.concurrentViewers
         ) {
-          this.liveViewerCache = {
+          return {
             timestamp: moment().unix(),
             isLive: true,
             viewers: searchResult.liveStreamingDetails.concurrentViewers,
@@ -86,13 +86,11 @@ class YouTube {
               'YYYY-MM-DDTHH:mm:ssZ',
             ),
           };
-          return this.liveViewerCache;
         }
-        this.liveViewerCache = {
+        return {
           timestamp: moment().unix(),
           isLive: false,
         };
-        return this.liveViewerCache;
       });
   }
 

--- a/lib/services/youtube.js
+++ b/lib/services/youtube.js
@@ -10,9 +10,6 @@ class YouTube {
       version: 'v3',
       auth: this.configuration.YOUTUBE_API_KEY,
     });
-    this.channelId = '';
-    this.playlistId = '';
-    this.liveViewerCache = {};
     this.etags = {};
   }
 
@@ -61,13 +58,6 @@ class YouTube {
   }
 
   getChannelStatus() {
-    /* const now = moment().unix();
-    if (
-      this.liveViewerCache.timestamp &&
-      now - this.liveViewerCache.timestamp < this.configuration.liveViewerCountTimeToLiveSeconds
-    ) {
-      return Promise.resolve(this.liveViewerCache);
-    } */
     const key = 'getChannelStatus';
     return this.getActiveLiveBroadcastsVideoId()
       .then((id) =>
@@ -107,9 +97,6 @@ class YouTube {
   }
 
   getChannelsUploadedPlaylistId(user) {
-    if (this.playlistId) {
-      return Promise.resolve(this.playlistId);
-    }
     const key = 'getChannelsUploadedPlaylistId';
     return this.youtube.channels
       .list(
@@ -124,17 +111,10 @@ class YouTube {
         (response) =>
           _.find(response.data.items, ['kind', 'youtube#channel']).contentDetails.relatedPlaylists
             .uploads,
-      )
-      .then((playlistId) => {
-        this.playlistId = playlistId;
-        return this.playlistId;
-      });
+      );
   }
 
   getChannelIdFromUsername(user) {
-    if (this.channelId) {
-      return Promise.resolve(this.channelId);
-    }
     const key = 'getChannelIdFromUsername';
     return this.youtube.channels
       .list(
@@ -145,11 +125,7 @@ class YouTube {
         { headers: this.addEtagHeader(key) },
       )
       .then((response) => this.cacheResponse(key, response))
-      .then((response) => _.find(response.data.items, ['kind', 'youtube#channel']).id)
-      .then((channelId) => {
-        this.channelId = channelId;
-        return this.channelId;
-      });
+      .then((response) => _.find(response.data.items, ['kind', 'youtube#channel']).id);
   }
 
   /**

--- a/lib/services/youtube.js
+++ b/lib/services/youtube.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const google = require('googleapis').google; // eslint-disable-line prefer-destructuring
+const { google } = require('googleapis');
 const moment = require('moment');
 
 class YouTube {
@@ -13,6 +13,7 @@ class YouTube {
     this.channelId = '';
     this.playlistId = '';
     this.liveViewerCache = {};
+    this.etags = {};
   }
 
   getLatestUploadedVideo() {
@@ -20,26 +21,36 @@ class YouTube {
   }
 
   getListOfUploadedVideos() {
+    const key = 'getListOfUploadedVideos';
     return this.getChannelsUploadedPlaylistId(this.configuration.YOUTUBE_CHANNEL)
       .then((playlistId) =>
-        this.youtube.playlistItems.list({
-          part: 'snippet, contentDetails',
-          playlistId,
-        }),
+        this.youtube.playlistItems.list(
+          {
+            part: ['snippet', 'contentDetails'],
+            playlistId,
+          },
+          { headers: this.addEtagHeader(key) },
+        ),
       )
+      .then((response) => this.cacheResponse(key, response))
       .then((response) => response.data);
   }
 
   getActiveLiveBroadcastsVideoId() {
+    const key = 'getActiveLiveBroadcastsVideoId';
     return this.getChannelIdFromUsername(this.configuration.YOUTUBE_CHANNEL)
       .then((channelId) =>
-        this.youtube.search.list({
-          channelId,
-          eventType: 'live',
-          type: 'video',
-          part: 'snippet',
-        }),
+        this.youtube.search.list(
+          {
+            channelId,
+            eventType: 'live',
+            type: ['video'],
+            part: ['snippet'],
+          },
+          { headers: this.addEtagHeader(key) },
+        ),
       )
+      .then((response) => this.cacheResponse(key, response))
       .then((response) => _.find(response.data.items, ['kind', 'youtube#searchResult']))
       .then((searchResult) => {
         if (searchResult && searchResult.id && searchResult.id.videoId) {
@@ -50,20 +61,25 @@ class YouTube {
   }
 
   getChannelStatus() {
-    const now = moment().unix();
+    /* const now = moment().unix();
     if (
       this.liveViewerCache.timestamp &&
       now - this.liveViewerCache.timestamp < this.configuration.liveViewerCountTimeToLiveSeconds
     ) {
       return Promise.resolve(this.liveViewerCache);
-    }
+    } */
+    const key = 'getChannelStatus';
     return this.getActiveLiveBroadcastsVideoId()
       .then((id) =>
-        this.youtube.videos.list({
-          id,
-          part: 'liveStreamingDetails',
-        }),
+        this.youtube.videos.list(
+          {
+            id: [id],
+            part: ['liveStreamingDetails'],
+          },
+          { headers: this.addEtagHeader(key) },
+        ),
       )
+      .then((response) => this.cacheResponse(key, response))
       .then((response) => _.find(response.data.items, ['kind', 'youtube#video']))
       .then((searchResult) => {
         if (
@@ -94,11 +110,16 @@ class YouTube {
     if (this.playlistId) {
       return Promise.resolve(this.playlistId);
     }
+    const key = 'getChannelsUploadedPlaylistId';
     return this.youtube.channels
-      .list({
-        forUsername: user,
-        part: 'contentDetails',
-      })
+      .list(
+        {
+          forUsername: user,
+          part: ['contentDetails'],
+        },
+        { headers: this.addEtagHeader(key) },
+      )
+      .then((response) => this.cacheResponse(key, response))
       .then(
         (response) =>
           _.find(response.data.items, ['kind', 'youtube#channel']).contentDetails.relatedPlaylists
@@ -114,16 +135,51 @@ class YouTube {
     if (this.channelId) {
       return Promise.resolve(this.channelId);
     }
+    const key = 'getChannelIdFromUsername';
     return this.youtube.channels
-      .list({
-        forUsername: user,
-        part: 'id',
-      })
+      .list(
+        {
+          forUsername: user,
+          part: ['id'],
+        },
+        { headers: this.addEtagHeader(key) },
+      )
+      .then((response) => this.cacheResponse(key, response))
       .then((response) => _.find(response.data.items, ['kind', 'youtube#channel']).id)
       .then((channelId) => {
         this.channelId = channelId;
         return this.channelId;
       });
+  }
+
+  /**
+   * @param {string} key
+   * @param {T} response
+   * @returns {T}
+   * @template {import("gaxios").GaxiosResponse} T
+   */
+  cacheResponse(key, response) {
+    if (response.status === 304) {
+      return this.etags[key];
+    }
+    this.etags[key] = response;
+    return response;
+  }
+
+  getEtag(key) {
+    const response = this.etags[key];
+    if (response && response.data && response.data.etag) {
+      return response.data.etag;
+    }
+    return null;
+  }
+
+  addEtagHeader(key, headers = {}) {
+    const etag = this.getEtag(key);
+    if (etag) {
+      return Object.assign(headers, { 'If-None-Match': etag });
+    }
+    return headers;
   }
 }
 

--- a/tests/lib/services/youtube.test.js
+++ b/tests/lib/services/youtube.test.js
@@ -146,33 +146,4 @@ describe('Youtube Tests', () => {
         return assert.deepStrictEqual(response, { timestamp: 1603155310, isLive: false });
     });
   });
-
-  it('uses live viewer cache when not yet expired', function() {
-    return yt.getChannelStatus()
-    .then(function (response) {
-        return assert.deepStrictEqual(response, { timestamp: 1603155310, isLive: true, viewers: '1785', started: moment('2020-10-10T19:04:28Z', 'YYYY-MM-DDTHH:mm:ssZ') });
-    })
-    .then(() => {
-        this.clock.tick(1*60*1000);
-        return yt.getChannelStatus()
-        .then(function (response) {
-            return assert.deepStrictEqual(response, { timestamp: 1603155310, isLive: true, viewers: '1785', started: moment('2020-10-10T19:04:28Z', 'YYYY-MM-DDTHH:mm:ssZ') });
-        })
-    });
-  });
-
-  it('refreshes live viewer count when cache expired', function() {
-    return yt.getChannelStatus()
-    .then(function (response) {
-        return assert.deepStrictEqual(response, { timestamp: 1603155310, isLive: true, viewers: '1785', started: moment('2020-10-10T19:04:28Z', 'YYYY-MM-DDTHH:mm:ssZ') });
-    })
-    .then(() => {
-        this.clock.tick(6*60*1000);
-        return yt.getChannelStatus()
-        .then(function (response) {
-            const timestamp = 1603155310+(6*60);
-            return assert.deepStrictEqual(response, { timestamp, isLive: true, viewers: '1785', started: moment('2020-10-10T19:04:28Z', 'YYYY-MM-DDTHH:mm:ssZ') });
-        })
-    });
-  });
 });

--- a/tests/lib/services/youtube.test.js
+++ b/tests/lib/services/youtube.test.js
@@ -20,7 +20,7 @@ describe('Youtube Tests', () => {
     return {
         channels: {
             list: function(payload){
-                switch(payload.part) {
+                switch(payload.part.join(',')) {
                     case 'contentDetails':
                         return Promise.resolve({ data: mockResponses.getChannelsUploadedPlaylistId });
                     case 'id':
@@ -86,7 +86,7 @@ describe('Youtube Tests', () => {
 
     return yt.getChannelsUploadedPlaylistId(config.YOUTUBE_CHANNEL)
     .then(function () {
-        return assert.strictEqual(yt.playlistId, "UU554eY5jNUfDq3yDOJYirOQ");
+        return assert.strictEqual(yt.etags['getChannelsUploadedPlaylistId'].data.items[0].contentDetails.relatedPlaylists.uploads, 'UU554eY5jNUfDq3yDOJYirOQ')
     });
   });
 
@@ -115,7 +115,7 @@ describe('Youtube Tests', () => {
   it('Gets the channel id from username and caches it', function() {
     return yt.getChannelIdFromUsername(config.YOUTUBE_CHANNEL)
     .then(function () {
-        return assert.strictEqual(yt.channelId, 'UC554eY5jNUfDq3yDOJYirOQ')
+        return assert.strictEqual(yt.etags['getChannelIdFromUsername'].data.items[0].id, 'UC554eY5jNUfDq3yDOJYirOQ')
     });
 });
 


### PR DESCRIPTION
This should drastically reduce quota usage for youtube api.

Questions:
- ~Should the old cache logic be removed?~
- Should we dump the `this.etags` into the DB to persists the etags further reducing quota cost?

Todo:

- [x] Fix tests