### PR TITLE
Fix punishment time parsing regex to work with 'perm'

### DIFF
--- a/lib/commands/base-punishment-helper.js
+++ b/lib/commands/base-punishment-helper.js
@@ -3,9 +3,10 @@ const parseDurationToSeconds = require('../chat-utils/duration-parser');
 
 // Durations in seconds
 function basePunishmentHelper(input, defaultBanTime, overRideDuration) {
-  const matched = /\s*((?:\d+[HMDSWwhmds])\s+|(?:perm)\s+)?\s?(\w+(?:\s*,\s*\w+)*)(?:\s(.*))?/.exec(
+  const matched = /\s*(?:((?:\d+[HMDSWwhmds])|(?:perm))\s+)?\s?(\w+(?:\s*,\s*\w+)*)(?:\s(.*))?/.exec(
     input,
   );
+  console.log(matched);
   const usersToPunish = _.get(matched, 2, '')
     .toLowerCase()
     .split(',')

--- a/tests/lib/commands/base-punishment-helper.test.js
+++ b/tests/lib/commands/base-punishment-helper.test.js
@@ -1,76 +1,97 @@
-const basePunishmentHelper = require("../../../lib/commands/base-punishment-helper");
-const assert = require("assert");
+const basePunishmentHelper = require('../../../lib/commands/base-punishment-helper');
+const assert = require('assert');
 
-describe("BasePunishmentHelper Tests", () => {
-  it("punish one for time for reason", function(done) {
-    const input = "20m Bob for being stupid";
+describe('BasePunishmentHelper Tests', () => {
+  it('punish one for time for reason', function (done) {
+    const input = '20m Bob for being stupid';
     const output = basePunishmentHelper(input, 3600);
     const expected = [
       {
-        userToPunish: "bob",
+        userToPunish: 'bob',
         parsedDuration: 1200,
-        parsedReason: "for being stupid",
-        isPermanent: false
-      }
+        parsedReason: 'for being stupid',
+        isPermanent: false,
+      },
     ];
 
     assert.deepStrictEqual(output, expected);
     done();
   });
-  it("punish one with overRideDuration", function(done) {
-    const input = "20m Bob for being stupid";
+  it('punish one with overRideDuration', function (done) {
+    const input = '20m Bob for being stupid';
     const output = basePunishmentHelper(input, 3600, 1800);
     const expected = [
       {
-        userToPunish: "bob",
+        userToPunish: 'bob',
         parsedDuration: 1800,
-        parsedReason: "for being stupid",
-        isPermanent: false
-      }
+        parsedReason: 'for being stupid',
+        isPermanent: false,
+      },
     ];
 
     assert.deepStrictEqual(output, expected);
     done();
   });
-  it("punish one with default time", function(done) {
-    const input = "Bob for being stupid";
+  it('punish one with default time', function (done) {
+    const input = 'Bob for being stupid';
     const output = basePunishmentHelper(input, 3600);
     const expected = [
       {
-        userToPunish: "bob",
+        userToPunish: 'bob',
         parsedDuration: 3600,
-        parsedReason: "for being stupid",
-        isPermanent: false
-      }
+        parsedReason: 'for being stupid',
+        isPermanent: false,
+      },
     ];
 
     assert.deepStrictEqual(output, expected);
     done();
   });
-  it("punish many with time", function(done) {
-    const input = "20m Bob, Kogasa, MrMouton for being stupid";
+  it('punish many with time', function (done) {
+    const input = '20m Bob, Kogasa, MrMouton for being stupid';
     const output = basePunishmentHelper(input, 3600);
     const expected = [
       {
-        userToPunish: "bob",
+        userToPunish: 'bob',
         parsedDuration: 1200,
-        parsedReason: "for being stupid",
-        isPermanent: false
+        parsedReason: 'for being stupid',
+        isPermanent: false,
       },
       {
-        userToPunish: "kogasa",
+        userToPunish: 'kogasa',
         parsedDuration: 1200,
-        parsedReason: "for being stupid",
-        isPermanent: false
+        parsedReason: 'for being stupid',
+        isPermanent: false,
       },
       {
-        userToPunish: "mrmouton",
+        userToPunish: 'mrmouton',
         parsedDuration: 1200,
-        parsedReason: "for being stupid",
-        isPermanent: false
-      }
+        parsedReason: 'for being stupid',
+        isPermanent: false,
+      },
     ];
 
+    assert.deepStrictEqual(output, expected);
+    done();
+  });
+
+  it('punish many with perm!', function (done) {
+    const input = 'perm Tony, DoubleYou for being stupid';
+    const output = basePunishmentHelper(input, 3600);
+    const expected = [
+      {
+        userToPunish: 'tony',
+        parsedDuration: 0,
+        parsedReason: 'for being stupid',
+        isPermanent: true,
+      },
+      {
+        userToPunish: 'doubleyou',
+        parsedDuration: 0,
+        parsedReason: 'for being stupid',
+        isPermanent: true,
+      },
+    ];
     assert.deepStrictEqual(output, expected);
     done();
   });

--- a/tests/lib/services/message-matching.test.js
+++ b/tests/lib/services/message-matching.test.js
@@ -2,7 +2,7 @@ const { hasLink, getLinks, mentionsUser } = require('../../../lib/services/messa
 const assert = require('assert');
 
 describe('Message matching tests ', () => {
-  describe('hasLink matches link-containing messages', function() {
+  describe('hasLink matches link-containing messages', function () {
     const goodLinkMessages = [
       'http://mrlinux.com',
       'http://test.tv',
@@ -32,7 +32,7 @@ describe('Message matching tests ', () => {
       });
     });
   });
-  describe('hasLink does not match non-link-containing messages', function() {
+  describe('hasLink does not match non-link-containing messages', function () {
     const badLinkMessages = ['random message in chat.', 'https://.....', 'yeah localhost', 'test.'];
     badLinkMessages.forEach((msg, i) => {
       it(`hasLink does not match non-link-containing message #${i + 1}`, () =>
@@ -40,19 +40,19 @@ describe('Message matching tests ', () => {
     });
   });
 
-  describe('getLinks lists links correctly', function() {
-    const links = ['http://destiny.gg', 'http://twitter.com', 'http://google.com'];
+  describe('getLinks lists links correctly', function () {
+    const links = ['http://destiny.gg/', 'http://twitter.com/', 'http://google.com/'];
     const messageWithLinks = `look at all these pretty links ${links.join(' ')}`;
 
     const foundLinks = getLinks(messageWithLinks);
     links.forEach((link, i) => {
-      it(`getLinks lists links correctly #${i+1}`, () => {
+      it(`getLinks lists links correctly #${i + 1}`, () => {
         assert.deepStrictEqual(foundLinks[i].href, link);
       });
     });
   });
 
-  describe('mentionUser matches actual mentions of a user', function() {
+  describe('mentionUser matches actual mentions of a user', function () {
     it('matches #1', () => assert.deepStrictEqual(mentionsUser('Destiny hi', 'desTiny'), true));
     it('matches #2', () => assert.deepStrictEqual(mentionsUser('DesTiny hi', 'desTiny'), true));
     it('matches #3', () =>

--- a/tests/lib/services/punishment-read-write-stream.test.js
+++ b/tests/lib/services/punishment-read-write-stream.test.js
@@ -1,47 +1,49 @@
 const assert = require('assert');
-const PunishmentCache = require('../../../../lib/services/punishment-cache.js');
-const PunishmentReadWriteStream = require('../../../../lib/services/punishment-read-write-stream.js');
+const PunishmentCache = require('../../../lib/services/punishment-cache.js');
+const PunishmentReadWriteStream = require('../../../lib/services/punishment-read-write-stream.js');
 
 describe('Mute capping tests', () => {
-  beforeEach(function() {
+  beforeEach(function () {
     this.mockServices = {
-      punishmentCache: new PunishmentCache({maxMuteSeconds: 100}),
+      punishmentCache: new PunishmentCache({ maxMuteSeconds: 100 }),
     };
   });
 
-  it('limits mute duration to non-negative numbers', function() {
+  it('limits mute duration to non-negative numbers', function () {
     const punishmentReadWriteStream = new PunishmentReadWriteStream(this.mockServices);
     punishmentReadWriteStream.sendMute('mute', -10, 'mute', 'tommy');
     assert.deepStrictEqual(0, punishmentReadWriteStream.read().duration);
   });
 
-  it('does not change the duration when the input duration is exactly 0', function() {
+  it('does not change the duration when the input duration is exactly 0', function () {
     const punishmentReadWriteStream = new PunishmentReadWriteStream(this.mockServices);
     punishmentReadWriteStream.sendMute('mute', 0, 'mute', 'tommy');
     assert.deepStrictEqual(0, punishmentReadWriteStream.read().duration);
   });
 
-  it('does not change the duration when the input duration is between 0 and maxMuteDurationSeconds', function() {
+  it('does not change the duration when the input duration is between 0 and maxMuteDurationSeconds', function () {
     const punishmentReadWriteStream = new PunishmentReadWriteStream(this.mockServices);
     punishmentReadWriteStream.sendMute('mute', 10, 'mute', 'tommy');
     assert.deepStrictEqual(10, punishmentReadWriteStream.read().duration);
   });
 
-  it('does not change the duration when the input duration is exactly maxMuteDurationSeconds', function() {
+  it('does not change the duration when the input duration is exactly maxMuteDurationSeconds', function () {
     const punishmentReadWriteStream = new PunishmentReadWriteStream(this.mockServices);
     punishmentReadWriteStream.sendMute('mute', 100, 'mute', 'tommy');
     assert.deepStrictEqual(100, punishmentReadWriteStream.read().duration);
   });
 
-  it('caps mute duration to maxMuteDurationSeconds', function() {
+  it('caps mute duration to maxMuteDurationSeconds', function () {
     const punishmentReadWriteStream = new PunishmentReadWriteStream(this.mockServices);
     punishmentReadWriteStream.sendMute('mute', 200, 'mute', 'tommy');
     assert.deepStrictEqual(100, punishmentReadWriteStream.read().duration);
   });
 
-  it('throws a TypeError if the mute duration is a string', function() {
+  it('throws a TypeError if the mute duration is a string', function () {
     const punishmentReadWriteStream = new PunishmentReadWriteStream(this.mockServices);
     punishmentReadWriteStream.sendMute('mute', 'OOO', 'mute', 'tommy');
-    assert.throws(() => {punishmentReadWriteStream.sendMute().read(), TypeError});
+    assert.throws(() => {
+      punishmentReadWriteStream.sendMute().read(), TypeError;
+    });
   });
 });


### PR DESCRIPTION
This PR fixes a bug where using `perm` as a time input to a punishment command wasn't parsed correctly and wouldn't run, i.e `!ban perm user, user2 for being bad`.

The issue was simply that the duration for any punishment was being matched with an extra space afterwards. For time durations this wasn't an issue, since it was then further parsed using regex that didn't care about the extra space, but `perm` was being matched directly against a string, so having `"perm "` instead of `"perm"` made it fail every time.

The fix here was to move a matched `\s` (whitespace) outside of the inner capture group into a surrounding non-capture group.