### PR TITLE
Fix !unnuke not working with regex

### DIFF
--- a/lib/commands/implementations/aegis.js
+++ b/lib/commands/implementations/aegis.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const Command = require('../command-interface');
 const CommandOutput = require('../command-output');
 const { makeUnban } = require('../../chat-utils/punishment-helpers');
@@ -20,12 +21,16 @@ function aegis(input, services) {
 }
 
 function aegisSingle(input, services) {
-  const usersToUnmute = services.punishmentCache.getNukedUsersForPhrase(input);
-  services.punishmentCache.cleanseSingleNuke(input);
+  const matched = /(?:\/(.*)\/)?(.*)/.exec(input);
+  const aegisWord = _.get(matched, 2).toLowerCase();
+  const aegisRegex = _.get(matched, 1, '');
+  const wordToUnnuke = aegisRegex === '' ? aegisWord : (new RegExp(aegisRegex, 'i')).toString();
+  const usersToUnmute = services.punishmentCache.getNukedUsersForPhrase(wordToUnnuke);
+  services.punishmentCache.cleanseSingleNuke(wordToUnnuke);
   if (usersToUnmute.length === 0) {
     return new CommandOutput(null, 'Removed phrase (unless it didnt exist, then I did nothing');
   }
-  services.punishmentCache.cleanseSingleNuke(input);
+  services.punishmentCache.cleanseSingleNuke(wordToUnnuke);
 
   usersToUnmute.forEach((user) => {
     services.punishmentStream.write(makeUnban(user, false));
@@ -33,7 +38,7 @@ function aegisSingle(input, services) {
 
   return new CommandOutput(
     null,
-    `Removing nuked phrase ${input}! Unmuting ${usersToUnmute.length} users AngelThump`,
+    `Removing nuked phrase "${wordToUnnuke}"! Unmuting ${usersToUnmute.length} users AngelThump`,
   );
 }
 

--- a/lib/services/punishment-cache.js
+++ b/lib/services/punishment-cache.js
@@ -76,11 +76,17 @@ class PunishmentCache {
 
   cleanseSingleNuke(nukeToRemove) {
     this.nukedPhrases = this.nukedPhrases.filter(
-      (nukedPhrase) => nukedPhrase.phrase.toLowerCase() !== nukeToRemove.toLowerCase(),
+      (nukedPhrase) => {
+        const curPhrase = (nukedPhrase.phrase instanceof RegExp) ? nukedPhrase.phrase.toString() : nukedPhrase.phrase
+        return curPhrase.toLowerCase() !== nukeToRemove.toLowerCase()
+      },
     );
 
     this.aegisCache = this.aegisCache.filter(
-      (nukedPhrase) => nukedPhrase.nukedPhrase.toLowerCase() !== nukeToRemove.toLowerCase(),
+      (nukedPhrase) => {
+        const curPhrase = (nukedPhrase.nukedPhrase instanceof RegExp) ? nukedPhrase.nukedPhrase.toString() : nukedPhrase.nukedPhrase
+        return curPhrase.toLowerCase() !== nukeToRemove.toLowerCase()
+      },
     );
   }
 
@@ -92,7 +98,8 @@ class PunishmentCache {
   getNukedUsersForPhrase(nukePhrase) {
     const users = [];
     _.forIn(this.singleUserAegisCache, (value, key) => {
-      if (value.phrase.toLowerCase() === nukePhrase.toLowerCase()) {
+      const curValue = (value.phrase instanceof RegExp) ? value.phrase.toString() : value.phrase
+      if (curValue.toLowerCase() === nukePhrase.toLowerCase()) {
         users.push(key);
       }
     });


### PR DESCRIPTION
Currently trying to !unnuke a regex you previously nuked causes the bot to error out, seems like a good thing to fix!

![image](https://user-images.githubusercontent.com/41237021/190927763-eb08eed4-cb3e-4eb2-a8f2-bc117ec4cba9.png)

This is what happens currently: if you try to !unnuke a regex, the bot doesn't respond and doesn't unban anyone, just sends an error to the console.

<details>
<summary>Current behavior (video + pic of error)</summary>

https://user-images.githubusercontent.com/41237021/190927906-ca88da14-a607-44ac-9068-39209f68af42.mp4

![ksnip_20220918-233821](https://user-images.githubusercontent.com/41237021/190927670-c322a952-e0cc-4412-bd05-838bc4219e7d.png)

</details>

With the fix everything seems to be working well! Granted, I haven't tested every single possibility, so some more testing would be nice, but both the regex and normal nukes get handled fine (in the mock-chat that has been modified to allow ban/unban messages and privileged users). I also added quotation marks around the unnuked phrase when it gets removed because I think it looks nicer/clearer :smile: But I can remove that of course, not essential at all :smiley: 

<details>
<summary>Fixed behavior (2 videos)</summary>

https://user-images.githubusercontent.com/41237021/190928059-8263de0e-6ab8-44f2-9430-dfe117824cbe.mp4

https://user-images.githubusercontent.com/41237021/190928056-0d344d03-435c-48c0-bd18-9407e77676c1.mp4

</details>

:heart: 