### PR TITLE
Post new tweet to chat.

### DIFF
--- a/lib/configuration/sample.config.json
+++ b/lib/configuration/sample.config.json
@@ -89,6 +89,7 @@
     "channelId": "yourChannel"
   },
   "twitter": {
+    "streamFilter": "from:TheOmniLiberal -is:retweet",
     "bearerToken": "",
     "cacheClearingInterval": 600,
     "maxCacheAge": 3600

--- a/lib/configuration/sample.config.json
+++ b/lib/configuration/sample.config.json
@@ -89,8 +89,6 @@
     "channelId": "yourChannel"
   },
   "twitter": {
-    "consumerKey": "",
-    "consumerSecret": "",
     "bearerToken": "",
     "cacheClearingInterval": 600,
     "maxCacheAge": 3600

--- a/lib/services/service-index.js
+++ b/lib/services/service-index.js
@@ -44,8 +44,8 @@ class Services {
     );
     this.fakeScheduler = new FakeScheduler(serviceConfigurations.schedule);
     this.dggApi = new DggApi(serviceConfigurations.dggApi, this.logger);
-    this.twitterApi = new TwitterApi(serviceConfigurations.twitter, this.logger);
     this.messageRelay = new MessageRelay();
+    this.twitterApi = new TwitterApi(serviceConfigurations.twitter, this.logger, this.messageRelay);
     this.messageMatching = messageMatchingService;
     this.htmlMetadata = new HTMLMetadata();
     // Since reddit relies on managing a single instance of a script, it only runs on the DGG bot.

--- a/lib/services/twitter-api.js
+++ b/lib/services/twitter-api.js
@@ -69,7 +69,6 @@ class TwitterApi {
       this.stream = await this.client.v2.searchStream();
       this.updateStreamRules();
       this.stream.on(TwitterEvent.Data, (event) => {
-        this.logger.info(`New Tweet: ${event.data.text}`);
         this.messageRelay.sendOutputMessage(`New Tweet: ${event.data.text}`);
       });
       this.stream.autoReconnect = true;

--- a/lib/services/twitter-api.js
+++ b/lib/services/twitter-api.js
@@ -9,7 +9,7 @@ class TwitterApi {
     this.dateFormat = config.dateFormat || 'ddd MMM DD HH:mm:ss Z YYYY';
 
     this.stream = null;
-    this.streamFilter = 'from:TheOmniLiberal -is:retweet';
+    this.streamFilter = config.streamFilter || 'from:TheOmniLiberal -is:retweet';
 
     this.cacheClearingInterval = config.cacheClearingInterval || 600;
     this.maxCacheAge = config.maxCacheAge || 3600;

--- a/lib/services/twitter-api.js
+++ b/lib/services/twitter-api.js
@@ -1,24 +1,26 @@
-const Twitter = require('twitter');
+const { TwitterApi: Twitter, ETwitterStreamEvent: TwitterEvent } = require('twitter-api-v2');
+const bigInt = require('big-integer');
 const moment = require('moment');
 const _ = require('lodash');
 
 class TwitterApi {
-  constructor(config, logger) {
-    this.client = new Twitter({
-      consumer_key: config.consumerKey,
-      consumer_secret: config.consumerSecret,
-      bearer_token: config.bearerToken,
-    });
+  constructor(config, logger, messageRelay) {
+    this.client = new Twitter(config.bearerToken);
     this.dateFormat = config.dateFormat || 'ddd MMM DD HH:mm:ss Z YYYY';
+
+    this.stream = null;
+    this.streamFilter = 'from:TheOmniLiberal -is:retweet';
 
     this.cacheClearingInterval = config.cacheClearingInterval || 600;
     this.maxCacheAge = config.maxCacheAge || 3600;
     // caching could be done using redis service
     this.tweetsCache = {};
     this.logger = logger || console;
+    this.messageRelay = messageRelay;
     this.timeStampKey = 'twitter';
 
     this.startCacheClearing();
+    this.startStream();
   }
 
   static getTweetId(message) {
@@ -42,28 +44,48 @@ class TwitterApi {
     }, this.cacheClearingInterval);
   }
 
+  async updateStreamRules() {
+    const rules = await this.client.v2.streamRules();
+    if (rules.data) {
+      const ruleIndex = rules.data.findIndex((rule) => rule.tag === 'streamer_tweets');
+      if (ruleIndex >= 0) {
+        if (rules.data[ruleIndex].value === this.streamFilter) return;
+        await this.client.v2.updateStreamRules({
+          delete: {
+            ids: [
+              ...rules.data.filter((rule) => rule.tag === 'streamer_tweets').map((rule) => rule.id),
+            ],
+          },
+        });
+      }
+    }
+    await this.client.v2.updateStreamRules({
+      add: [{ value: this.streamFilter, tag: 'streamer_tweets' }],
+    });
+  }
+
+  async startStream() {
+    try {
+      this.stream = await this.client.v2.searchStream();
+      this.updateStreamRules();
+      this.stream.on(TwitterEvent.Data, (event) => {
+        this.logger.info(`New Tweet: ${event.data.text}`);
+        this.messageRelay.sendOutputMessage(`New Tweet: ${event.data.text}`);
+      });
+      this.stream.autoReconnect = true;
+    } catch (error) {
+      this.logger.error('Problem creating twitter stream', error);
+    }
+  }
+
   getTweetDatetime(tweetId) {
     return new Promise((resolve, reject) => {
       if (!tweetId) return reject(new Error('invalid tweet link'));
       if (this.tweetsCache[tweetId]) return resolve(this.tweetsCache[tweetId].createdAt);
-      return this.client
-        .get('statuses/show.json', { id: tweetId })
-        .then((response) => {
-          const createdAt = _.get(response, 'created_at', null);
-          if (!createdAt) {
-            this.logger.error('Tweet data missing creation date', response);
-            return reject();
-          }
-          this.tweetsCache[tweetId] = {
-            cachedAt: moment(),
-            createdAt,
-          };
-          return resolve(moment(createdAt, this.dateFormat));
-        })
-        .catch((errors) => {
-          this.logger.error('Problem retrieving tweet data', errors);
-          reject(errors);
-        });
+      if (tweetId.length <= 13) return resolve(moment('2010-10-31T12:00:00.000Z', this.dateFormat));
+
+      const date = new Date(+bigInt(tweetId).shiftRight(22) + 1288834974657);
+      return resolve(moment(date, this.dateFormat));
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "axios": "^0.20.0",
+    "big-integer": "^1.6.51",
     "bunyan": "^1.8.14",
     "fast-levenshtein": "^3.0.0",
     "google-auth-library": "^6.1.1",
@@ -29,7 +30,7 @@
     "protobufjs": "^6.10.1",
     "sqlite3": "^5.0.0",
     "twitch-js": "^1.2.17",
-    "twitter": "^1.7.1",
+    "twitter-api-v2": "^1.14.1",
     "ws": "^7.3.1",
     "yargs": "^16.0.3"
   },


### PR DESCRIPTION
Twitter improvements.
- Listen for a new tweet and post it to chat.
- Get tweet date by converting twitter snowflake id to timestamp instead of from api.