### PR TITLE
Change default location of database file

### DIFF
--- a/lib/configuration/sample.config.json
+++ b/lib/configuration/sample.config.json
@@ -16,7 +16,7 @@
     "url": "https://overrustlelogs.net"
   },
   "sql": {
-    "fileLocation": "/usr/src/app/database/bot.db"
+    "fileLocation": "./bot.db"
   },
   "chatCache": {
     "messagesToKeepPerUser": 10,


### PR DESCRIPTION
Attempting to create the database file in `/usr/src` fails due to lack of permissions and is inappropriate for a dev environment in general. The best approach is to simply keep it close to source files.