### PR TITLE
Fix triggering spam if mention twice and then don't mention.

### DIFF
--- a/lib/message-routing/message-router.js
+++ b/lib/message-routing/message-router.js
@@ -109,6 +109,7 @@ class MessageRouter {
       this.spamDetection.checkListOfRecentUrlsForSpam(
         messageContent,
         this.chatCache.getViewerUrlList(user),
+        this.chatCache.messageUrlSpamUser,
       ),
     ];
 

--- a/lib/services/dgg-rolling-chat-cache.js
+++ b/lib/services/dgg-rolling-chat-cache.js
@@ -79,12 +79,7 @@ class ChatCache {
   }
 
   addMessageToViewerUrlMap(user, message) {
-    if (
-      this.messageUrlSpamUser &&
-      !this.messageMatching.mentionsUser(message, this.messageUrlSpamUser)
-    ) {
-      return;
-    }
+    if (!this.messageMatching.mentionsUser(message, this.messageUrlSpamUser)) return;
     this.messageMatching.getLinks(message).forEach((link) => {
       this.logger.info(
         { user, url: link.hostname + link.pathname, msg: message },

--- a/lib/services/spam-detection.js
+++ b/lib/services/spam-detection.js
@@ -118,7 +118,8 @@ class SpamDetection {
     return this.isSimilarityAboveThreshold(matchPercents);
   }
 
-  checkListOfRecentUrlsForSpam(message, urlList) {
+  checkListOfRecentUrlsForSpam(message, urlList, mentionUser = null) {
+    if (mentionUser && !this.messageMatching.mentionsUser(message, mentionUser)) return false;
     return this.messageMatching.getLinks(message).some((link) => {
       return (
         urlList.filter((url) => url === link.hostname + link.pathname).length >=

--- a/lib/services/spam-detection.js
+++ b/lib/services/spam-detection.js
@@ -119,7 +119,7 @@ class SpamDetection {
   }
 
   checkListOfRecentUrlsForSpam(message, urlList, mentionUser = null) {
-    if (mentionUser && !this.messageMatching.mentionsUser(message, mentionUser)) return false;
+    if (!this.messageMatching.mentionsUser(message, mentionUser)) return false;
     return this.messageMatching.getLinks(message).some((link) => {
       return (
         urlList.filter((url) => url === link.hostname + link.pathname).length >=


### PR DESCRIPTION
This fixes a user mentioning destiny twice with a link then doesn't mention with the same link and still triggering the spam detection. 