### PR TITLE
Add manually-triggered release workflow

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,11 @@
+changelog:
+  categories:
+    - title: New features
+      labels:
+        - enhancement
+    - title: Bugfixes
+      labels:
+        - bug
+    - title: Other changes
+      labels:
+        - '*'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -64,3 +65,9 @@ jobs:
           gh release create "${{ steps.bump.outputs.new_version }}" \
             --title "${{ steps.bump.outputs.new_version }}" \
             --generate-notes
+
+      - name: Trigger ECR build
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run ecr-chatbot-prod.yml --ref "${{ steps.bump.outputs.new_version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: 'Version bump type'
+        required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Bump version and release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: |
+          cp lib/configuration/sample.config.json lib/configuration/prod.config.json
+          npm test
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump version, commit, tag
+        id: bump
+        run: |
+          NEW_VERSION=$(npm version ${{ inputs.version_type }} -m "%s")
+          echo "new_version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Push commit and tag
+        run: git push --follow-tags origin master
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.bump.outputs.new_version }}" \
+            --title "${{ steps.bump.outputs.new_version }}" \
+            --generate-notes


### PR DESCRIPTION
## Summary
- New `.github/workflows/release.yml` triggered via `workflow_dispatch` with a `version_type` input (patch/minor/major). Runs lint + tests, bumps via `npm version`, pushes the commit and `v*` tag to master, and publishes a GitHub Release with auto-generated notes. The pushed tag fires the existing ECR build workflow.
- New `.github/release.yml` groups auto-generated release notes into **New features** (`enhancement`), **Bugfixes** (`bug`), and **Other changes** (catch-all).

## Test plan
- [ ] Merge, then run **Actions → Release → Run workflow** with `patch`
- [ ] Confirm lint + tests pass, version commit lands on master, `v*` tag is pushed
- [ ] Verify GitHub Release is created with categorized auto-generated notes
- [ ] Verify the existing ECR workflow fires from the new tag and pushes the image